### PR TITLE
Fix PWM loop for blinking LED

### DIFF
--- a/all/PWM-X2C-EXAMPLE.X/main.c
+++ b/all/PWM-X2C-EXAMPLE.X/main.c
@@ -94,15 +94,13 @@ int main(void)
     while (1)
     {
         /*
-         * Simple duty-cycle toggle to verify PWM operation.
-         * The duty is set to 100% for half a second and then
-         * forced to 0% for another half second.
+         * Drive PWM1 with a "breathe" pattern.  The helper
+         * routine updates the duty-cycle and waits
+         * STEP_DELAY_MS between each step.  Calling the blink
+         * update on every step keeps the debug LED toggling at
+         * the desired rate.
          */
-        PWM_DutyCycleSet(PWM_GENERATOR_1, perCounts);
-        __delay_ms(500);
-        PWM_DutyCycleSet(PWM_GENERATOR_1, 0U);
-        __delay_ms(500);
-
+        APP_BreatheUpdate();
         APP_BlinkUpdate();      // lampeggio LED1
     }
 


### PR DESCRIPTION
## Summary
- update PWM example loop to run `APP_BreatheUpdate()`
- ensure debug LED blinks continuously while PWM runs

## Testing
- `make build`

------
https://chatgpt.com/codex/tasks/task_e_68651add85a083238f1ec53609e76e6f